### PR TITLE
Replace AppDomain.CurrentDomain with AssemblyBuilder.

### DIFF
--- a/Foq/Foq.fs
+++ b/Foq/Foq.fs
@@ -368,7 +368,7 @@ module internal Emit =
         let name = "Foq.Dynamic"
         /// Builder for assembly
         let assemblyBuilder =
-            AppDomain.CurrentDomain.DefineDynamicAssembly(AssemblyName(name),AssemblyBuilderAccess.Run)
+            AssemblyBuilder.DefineDynamicAssembly(AssemblyName(name),AssemblyBuilderAccess.Run)
         /// Builder for module
         assemblyBuilder.DefineDynamicModule(name+".dll")
         )


### PR DESCRIPTION
Allows it to build on .Net Core 2.0

The VS2017 project still builds and the tests passed straight off (bar a few unrelated fails due to FSharp.Core versions).

I tried doing this on 1.1 back when I mentioned it, but that was a nightmare due to missing stuff. They've added loads back in 2.0. It just needed this one change to get it working in my project.

Seemed like a good idea to get it uploaded so it was known about, should anyone else want to do it. Won't be offended if you don't actually complete it ;)