### PR TITLE
Fix for issue #21

### DIFF
--- a/Foq/Foq.fs
+++ b/Foq/Foq.fs
@@ -525,7 +525,8 @@ module internal Emit =
             let attr = BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance
             let allMethods = abstractType.GetMethods(attr)
             let hasMethod mi = allMethods |> Seq.exists (matches mi)
-            yield! allMethods |> Seq.filter (fun mi -> not mi.IsFinal)
+            let isEqualsMethod (mi : MethodInfo) = mi.Name = "Equals" && (let ps = mi.GetParameters() in ps.Length = 1 && ps.[0].ParameterType = typeof<obj>)
+            yield! allMethods |> Seq.filter (fun mi -> not mi.IsFinal && not (isEqualsMethod mi))
             let interfaces = abstractType.GetInterfaces()
             for interfaceType in interfaces do
                 yield! interfaceType.GetMethods() |> Seq.filter (not << hasMethod)

--- a/Tests/Tests.FSharp/AbstractClassTests.fs
+++ b/Tests/Tests.FSharp/AbstractClassTests.fs
@@ -10,6 +10,12 @@ type MyAbstractBaseClass() =
     abstract MyProperty : int
 
 [<Test>]
+let ``a mocked instance of an abstract base class is equal to itself`` () =
+    let mock = Mock<MyAbstractBaseClass>().Create()
+
+    Assert.IsTrue(mock.Equals(mock))
+
+[<Test>]
 let ``can mock an abstract base class method`` () =
     let mock = 
         Mock<MyAbstractBaseClass>


### PR DESCRIPTION
This is a fix for issue #21.

I don't know whether this is really the best way to resolve it - it just prevents the existing code from overriding the `Equals(_:obj)` method.