### PR TITLE
Update targets to .NET 5.0, NET Framework 4.72 and NET Framework 4.8.

### DIFF
--- a/Examples/Examples.fsproj
+++ b/Examples/Examples.fsproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45;net451;net452;net46;</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472;net48</TargetFrameworks>
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="FsUnit" Version="3.0.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="FsUnit" Version="4.0.4" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TaxExample.fs" />

--- a/Foq/Foq.fsproj
+++ b/Foq/Foq.fsproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Foq</AssemblyName>
     <Authors>Phillip Trelford</Authors>
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     <Description>Foq is a lightweight thread-safe mocking library for F#, C#, and VB with a similar API to Moq.</Description>
     <Copyright>Copyright 2012-2018</Copyright>
     <PackageReleaseNotes>Support for .NET Core/.NET Standard 2.0</PackageReleaseNotes>
@@ -15,12 +15,9 @@
     <PackageTags>F# C# VB testing unittest unittesting TDD stubs stubbing fakes faking mocks mocking moq</PackageTags>
     <PackageIconUrl>http://trelford.com/Foq.png</PackageIconUrl>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="3.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="4.2.3" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/Tests/Tests.CSharp/Tests.CSharp.csproj
+++ b/Tests/Tests.CSharp/Tests.CSharp.csproj
@@ -1,17 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net45</TargetFrameworks>
-    <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
+	  <TargetFrameworks>net5.0;net472;net48</TargetFrameworks>
+	  <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+		<NoWarn>NU1701</NoWarn>
+	</PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Tests/Tests.FSharp.Linq/Tests.FSharp.Linq.fsproj
+++ b/Tests/Tests.FSharp.Linq/Tests.FSharp.Linq.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472;net48</TargetFrameworks>
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -9,18 +9,11 @@
   <ItemGroup>
     <Compile Include="LinqTests.fs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="4.1.18" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="4.2.3" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+	  <PackageReference Include="FSharp.Core" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+	  <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Foq\Foq.fsproj" />

--- a/Tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/Tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472;net48</TargetFrameworks>
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -23,21 +23,16 @@
     <Compile Include="AsTests.fs" />
     <Compile Include="ComplexArgumentTests.fs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="4.1.18" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="FSharp.Core" Version="4.2.3" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+	  <PackageReference Include="FSharp.Core" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+	  <PackageReference Include="NUnit" Version="3.13.0" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+		  <NoWarn>NU1701</NoWarn>
+	  </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Foq\Foq.fsproj" />
-    <ProjectReference Include="..\Types.CSharp\Types.CSharp.csproj"/>
+    <ProjectReference Include="..\Types.CSharp\Types.CSharp.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/Tests.VisualBasic/Tests.VisualBasic.vbproj
+++ b/Tests/Tests.VisualBasic/Tests.VisualBasic.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472;net48</TargetFrameworks>
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+		<NoWarn>NU1701</NoWarn>
+	</PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Foq\Foq.fsproj" />

--- a/Tests/Types.CSharp/Types.CSharp.csproj
+++ b/Tests/Types.CSharp/Types.CSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Created a new version with updated targets, so that package works well with latest versions of .NET SDK.

This PR is a draft with two open questions:

1) Which targets to include?
Suggest that package includes the versions supported by `dotnet 3.1`. Reason is a bug that always restores the latest `fsharp.core` version. 
More info about `fsharp.core` bug:
https://github.com/fsprojects/Paket/issues/3769

2) How to automate testing?
The run all test command in `appveyor-test.ps1` (`dotnet msbuild /m Tests/tests.proj`) does not work anymore, instead I've used `dotnet test Foq.sln`.
